### PR TITLE
Remove Python 2 support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Contributors
 * Vadim Pushtaev (@VadimPushtaev)
 * Martin Larralde (@althonos)
 * Qudus Oladipo (@stikks)
+* Sean Aubin (@seanny123)

--- a/README.rst
+++ b/README.rst
@@ -23,14 +23,13 @@ replacement with fully compatible API (import ``property_cached`` instead of
 ``cached_property`` in your code and *voilà*). In case development resumes on
 the original library, this one is likely to be deprecated.
 
-*Original readme included below:*
+*Slightly modified README included below:*
 
 Why?
 -----
 
 * Makes caching of time or computational expensive properties quick and easy.
 * Because I got tired of copy/pasting this code from non-web project to non-web project.
-* I needed something really simple that worked in Python 2 and 3.
 
 How to use it
 --------------

--- a/property_cached/__init__.py
+++ b/property_cached/__init__.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import asyncio
 import functools
 import pkg_resources
 import sys
 import threading
 import weakref
 from time import time
-
-try:
-    import asyncio
-except (ImportError, SyntaxError):
-    asyncio = None
 
 
 __author__ = "Martin Larralde"

--- a/property_cached/__init__.py
+++ b/property_cached/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import asyncio
 import functools
 import pkg_resources

--- a/property_cached/__init__.py
+++ b/property_cached/__init__.py
@@ -3,7 +3,6 @@
 import asyncio
 import functools
 import pkg_resources
-import sys
 import threading
 import weakref
 from time import time
@@ -23,17 +22,7 @@ class cached_property(property):
     """  # noqa
 
     _sentinel = object()
-
-    if sys.version_info[0] < 3:
-
-        def _update_wrapper(self, func):
-            self.__doc__ = getattr(func, "__doc__", None)
-            self.__module__ = getattr(func, "__module__", None)
-            self.__name__ = getattr(func, "__name__", None)
-
-    else:
-
-        _update_wrapper = functools.update_wrapper
+    _update_wrapper = functools.update_wrapper
 
     def __init__(self, func):
         self.cache = weakref.WeakKeyDictionary()


### PR DESCRIPTION
Although explicitly unsupported, there was still some code hanging around for Python 2, which is removed in this PR.